### PR TITLE
Initialize $env var

### DIFF
--- a/core/lib/schema-php-client/lib/Cache.php
+++ b/core/lib/schema-php-client/lib/Cache.php
@@ -38,6 +38,11 @@ class Cache
   public $indexes = [];
 
   /**
+   * @var string
+   */
+  protected $env;
+
+  /**
    * @param  string $client_id
    * @param  string $client_key
    * @param  array $options


### PR DESCRIPTION
It is missed to initialize $env variable inside the class.