### PR TITLE
Fix return type in Swell\\Client::params()

### DIFF
--- a/core/lib/schema-php-client/lib/Client.php
+++ b/core/lib/schema-php-client/lib/Client.php
@@ -154,9 +154,8 @@ class Client
       $this->params = array_merge($this->params, $merge);
     } elseif (is_string($key = $merge)) {
       return $this->params[$key];
-    } else {
-      return $this->params;
     }
+    return $this->params;
   }
 
   /**


### PR DESCRIPTION
Fix return type in Swell\\Client::params()

```sh
App Exception: Return value of Swell\\Client::params() must be of the type array, none returned in /schema/app/core/lib/schema-php-client/lib/Client.php on line 160 (code: 0)
```