### PR TITLE
feat: Add default value for verify_peer_name prop

### DIFF
--- a/core/lib/schema-php-client/lib/Connection.php
+++ b/core/lib/schema-php-client/lib/Connection.php
@@ -86,10 +86,12 @@ class Connection
       $options = [
         "ssl" => [
           "verify_peer" => false,
+          "verify_peer_name" => false
         ],
       ];
       if ($this->options["verify_cert"]) {
         $options["ssl"]["verify_peer"] = true;
+        $options["ssl"]["verify_peer_name"] = true;
         $options["ssl"]["verify_depth"] = 5;
         $options["ssl"]["cafile"] =
           \dirname(\dirname(__FILE__)) . "/data/ca-certificates.crt";


### PR DESCRIPTION
### Description

- Added default value for verify_peer_name prop

It allows easily connect schema php cdn to hosts different from `swell.store`, for example review apps